### PR TITLE
type_caster static method test cases & parse_decimal_field fix

### DIFF
--- a/data_utils/file_utils/fixed_width/type_caster.py
+++ b/data_utils/file_utils/fixed_width/type_caster.py
@@ -44,6 +44,8 @@ class TypeCaster:
             value = value.replace("{", "")
             if "." in value:
                 value = float(value)
+            elif value.startswith(('-', '+')):
+                value = float(f"{value[0]}{value[1:int(parts[0]) + 1]}.{value[int(parts[0]) + 1:]}")
             else:
                 value = float(f"{value[:int(parts[0])]}.{value[int(parts[0]):]}")
         except ValueError:

--- a/tests/test_type_caster.py
+++ b/tests/test_type_caster.py
@@ -32,23 +32,20 @@ def test_integer_val_parse_decimal_field():
 
 def test_parse_time_field():
     """string should be sliced to time format hh:mm:ss"""
-    parse_time_field: str = lambda x: TypeCaster._parse_time_field(value=x)
-    assert parse_time_field("hhmmss") == "hh:mm:ss"
-    assert parse_time_field("235000") == "23:50:00"
+    assert TypeCaster._parse_time_field("hhmmss") == "hh:mm:ss"
+    assert TypeCaster._parse_time_field("235000") == "23:50:00"
 
 
 def test_parse_date_string():
     """date time stings should be converted to date formats"""
-    parse_date_string: str = lambda x: TypeCaster._parse_date_string(date=x)
-    assert parse_date_string('03/28/21') == '2021-03-28'
-    assert parse_date_string('20210328') == '2021-03-28'
-    assert parse_date_string('03282021') == '2021-03-28'
-    assert parse_date_string('00010101') == '0001-01-01'
+    assert TypeCaster._parse_date_string('03/28/21') == '2021-03-28'
+    assert TypeCaster._parse_date_string('20210328') == '2021-03-28'
+    assert TypeCaster._parse_date_string('03282021') == '2021-03-28'
+    assert TypeCaster._parse_date_string('00010101') == '0001-01-01'
 
 
 def test_parse_expiration_date():
     """func should return date string with last date of month from input date string if date format is not mentioned"""
-    parse_exp_date: (str, str) = lambda x, y=None: TypeCaster._parse_expiration_date(date=x, date_format=y)
-    assert parse_exp_date('21-03-01', '%y-%m-%d') == '2021-03-01'
-    assert parse_exp_date('03/21') == '2021-03-31'
-    assert parse_exp_date('032021') == '2021-03-31'
+    assert TypeCaster._parse_expiration_date('21-03-01', '%y-%m-%d') == '2021-03-01'
+    assert TypeCaster._parse_expiration_date('03/21') == '2021-03-31'
+    assert TypeCaster._parse_expiration_date('032021') == '2021-03-31'

--- a/tests/test_type_caster.py
+++ b/tests/test_type_caster.py
@@ -1,4 +1,54 @@
+import pytest
+
+from data_utils.file_utils.fixed_width.type_caster import TypeCaster
 
 
-def test_cast_data_types():
-    assert 1 == 1
+def test_none_cast_data_types():
+    """if value is None the func should return None"""
+    result = TypeCaster.cast_data_types(None, value=None, data_type="", pic_clause="", field_name="")
+    assert result is None
+
+
+def test_parse_decimal_field_random():
+    """should return the original value with "{" removed if non decimal value is passed """
+    value = 'fail4sure{'
+    result = TypeCaster._parse_decimal_field(value=value, field_name='TRANSACTION_AMOUNT', pic_clause='-9(7).9(2)')
+    assert result == 'fail4sure'
+
+
+def test_parse_decimal_field_decimal_value():
+    """if input str is a float value then func should return float"""
+    value = '-0000123.45'
+    result = TypeCaster._parse_decimal_field(value=value, field_name='TRANSACTION_AMOUNT', pic_clause='-9(7).9(2)')
+    assert result == -0000123.45
+
+
+def test_integer_val_parse_decimal_field():
+    """if input is integer value should cast into decimal value based on pic clause"""
+    value = '-000012345'
+    result = TypeCaster._parse_decimal_field(value=value, field_name='TRANSACTION_AMOUNT', pic_clause='-9(7).9(2)')
+    assert result == -0000123.45
+
+
+def test_parse_time_field():
+    """string should be sliced to time format hh:mm:ss"""
+    parse_time_field: str = lambda x: TypeCaster._parse_time_field(value=x)
+    assert parse_time_field("hhmmss") == "hh:mm:ss"
+    assert parse_time_field("235000") == "23:50:00"
+
+
+def test_parse_date_string():
+    """date time stings should be converted to date formats"""
+    parse_date_string: str = lambda x: TypeCaster._parse_date_string(date=x)
+    assert parse_date_string('03/28/21') == '2021-03-28'
+    assert parse_date_string('20210328') == '2021-03-28'
+    assert parse_date_string('03282021') == '2021-03-28'
+    assert parse_date_string('00010101') == '0001-01-01'
+
+
+def test_parse_expiration_date():
+    """func should return date string with last date of month from input date string if date format is not mentioned"""
+    parse_exp_date: (str, str) = lambda x, y=None: TypeCaster._parse_expiration_date(date=x, date_format=y)
+    assert parse_exp_date('21-03-01', '%y-%m-%d') == '2021-03-01'
+    assert parse_exp_date('03/21') == '2021-03-31'
+    assert parse_exp_date('032021') == '2021-03-31'


### PR DESCRIPTION
Changes to parse_decimal_field function  & test cases for type_caster module:
- Added case for handling int strings startswith(('-', '+')).
- Test cases for type_caster static methods except unpack_number .
